### PR TITLE
Fix directory check syntax

### DIFF
--- a/github-install.sh
+++ b/github-install.sh
@@ -115,7 +115,7 @@ if [ "$DEBUG" == "TRUE" ]; then
 fi
 
 # Checkout the repo & enter it
-if [ -d "${$REPO_LOCATION}" ]; then
+if [ -d "${REPO_LOCATION}" ]; then
     cd $REPO_LOCATION
     git checkout master;
     git pull; 


### PR DESCRIPTION
## what
* Use proper bash variable notation

## why
* syntax error

```
/var/lib/helm/plugins/helm-github.git/github-install.sh: line 118: ${$REPO_LOCATION}: bad substitution
Error: plugin "github" exited with error
```