### PR TITLE
fix remote repository update

### DIFF
--- a/github.sh
+++ b/github.sh
@@ -120,16 +120,26 @@ fi
 
 # Checkout the repo & enter it
 if [ -d "${REPO_LOCATION}" ]; then
-    cd $REPO_LOCATION
-    git checkout master;
-    git pull;
+    # Repo already exists
+    cd "$REPO_LOCATION"
+    # Cleanup current working tree including untracked files
+    git reset --hard HEAD
+    git clean -dx --force
+    # Detach in case we're on a local branch
+    git checkout --detach
+    # Delete all local branches to not have to merge them all
+    for branch in $(git for-each-ref --format="%(refname:strip=2)" refs/heads); do
+        git branch -D $branch
+    done
+    # Update from remote
+    git fetch --force --all --tags --prune --prune-tags
 else
-    git clone $REPO $REPO_LOCATION;
-    cd $REPO_LOCATION;
+    git clone "$REPO" "$REPO_LOCATION";
+    cd "$REPO_LOCATION";
 fi
 
 # Checkout the correct branch 
-git checkout $BRANCH
+git checkout "$BRANCH"
 
 # Exit the repo
 cd -


### PR DESCRIPTION
when a remote repository is already cloned, it is now
properly updated, no matter if the provided ref is a
branch, tag or other commitish value.

the remote references are now properly updated,
so branches, tags and other commit-ish values
provided as refeference are resolved against the
recent remote.